### PR TITLE
Add HealthKit integration

### DIFF
--- a/src/components/health-kit.ts
+++ b/src/components/health-kit.ts
@@ -1,0 +1,71 @@
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators/custom-element.js';
+import { state } from 'lit/decorators/state.js';
+
+declare const window: Window & {
+    webkit?: any;
+};
+
+@customElement('health-kit-control')
+export class HealthKitControl extends LitElement {
+
+    @state() healthKitLog = '';
+    @state() iOSHealthKitCapability = false;
+    @state() healthKitPermission = '';
+    @state() healthKitData: any = null;
+
+    logMessage(message: string) {
+        console.log(message);
+        this.healthKitLog += `>: ${message}\r\n`;
+    }
+
+    async firstUpdated() {
+        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers['healthkit-permission-request'] && window.webkit.messageHandlers['healthkit-data-request']) {
+            this.iOSHealthKitCapability = true;
+        }
+
+        window.addEventListener('healthkit-permission-request', (event: any) => {
+            if (event && event.detail) {
+                this.healthKitPermission = event.detail;
+                this.logMessage(`HealthKit Permission: ${event.detail}`);
+            }
+        });
+
+        window.addEventListener('healthkit-data', (event: any) => {
+            if (event && event.detail) {
+                this.healthKitData = event.detail;
+                this.logMessage(`HealthKit Data: ${JSON.stringify(event.detail)}`);
+            }
+        });
+    }
+
+    healthKitPermissionRequest() {
+        if (this.iOSHealthKitCapability)
+            window.webkit.messageHandlers['healthkit-permission-request'].postMessage('healthkit-permission-request');
+        else
+            this.logMessage('HealthKit capability not available');
+    }
+
+    healthKitDataRequest() {
+        if (this.iOSHealthKitCapability)
+            window.webkit.messageHandlers['healthkit-data-request'].postMessage('healthkit-data-request');
+        else
+            this.logMessage('HealthKit capability not available');
+    }
+
+    render() {
+        return html`
+            <nord-card padding="m">
+                <h2 slot="header">HealthKit Integration</h2>
+                <p slot="header-end">iOS HealthKit Capability: ${this.iOSHealthKitCapability ? 'Available' : 'Not Available'}</p>
+                <nord-stack direction="horizontal">
+                    <nord-button variant="primary" @click="${this.healthKitPermissionRequest}">Request HealthKit Permission</nord-button>
+                    <nord-button variant="primary" @click="${this.healthKitDataRequest}">Request HealthKit Data</nord-button>
+                </nord-stack>
+                <p>HealthKit Permission: ${this.healthKitPermission}</p>
+                <p>HealthKit Data: ${JSON.stringify(this.healthKitData)}</p>
+                <nord-textarea readonly expand value="${this.healthKitLog}" placeholder="events log"></nord-textarea>
+            </nord-card>
+        `;
+    }
+}

--- a/src/pages/app-home.ts
+++ b/src/pages/app-home.ts
@@ -3,6 +3,7 @@ import { property, customElement, state } from 'lit/decorators.js';
 
 import "../components/in-app-purchase";
 import "../components/push";
+import "../components/health-kit";
 // import { resolveRouterPath } from '../router';
 
 import '@nordhealth/components/lib/Button.js';
@@ -119,7 +120,7 @@ export class AppHome extends LitElement {
 		</nord-card>
 		<push-control></push-control>
 		<iap-card></iap-card>
-
+		<health-kit-control></health-kit-control>
 		<nord-card padding="none">
 			<h2 slot="header">Web APIs demos</h2>
 			<nord-nav-group>


### PR DESCRIPTION
This PR introduces a new HealthKit integration component to our iOS PWA Shell application. The changes include:

1. Created a new `health-kit-control` component (`src/components/health-kit.ts`) that handles HealthKit interactions.
2. Updated `app-home.ts` to include the new HealthKit component.

Key features:
- Check for iOS HealthKit capability
- Request HealthKit permissions
- Request HealthKit data
- Display HealthKit permission status and received data
- Log HealthKit-related events

The new component follows the existing code structure and UI design, integrating seamlessly with our current Nord Design System components.

To test:
1. Run the application on an iOS device or simulator with HealthKit capabilities.
2. Verify that the HealthKit card appears on the home screen.
3. Test the "Request HealthKit Permission" and "Request HealthKit Data" buttons.
4. Confirm that the component correctly displays HealthKit capability, permission status, and received data.